### PR TITLE
Manage and track top holder wallets

### DIFF
--- a/gmgn-tracker/content.js
+++ b/gmgn-tracker/content.js
@@ -1,0 +1,174 @@
+(function() {
+  const STORAGE_KEY = 'gmgnTopHolderOriginals';
+  const TAG_ATTR = 'data-gmgn-tracker-tag';
+
+  function getTopHolderNameNodes() {
+    // Heuristic: Look for common holder tables/lists within the Top holders tab
+    const candidateRoots = [];
+    // GMGN often renders with data-reactroot or within content area
+    candidateRoots.push(...document.querySelectorAll('[data-reactroot], main, .ant-table, .ant-list, .holder-list'));
+
+    const nameNodes = new Set();
+
+    const holderRowSelectors = [
+      'tr',
+      '.ant-table-row',
+      '.holder-row',
+      'li',
+      '.list-item'
+    ];
+
+    const nameCellSelectors = [
+      // common selectors that may contain wallet name/address
+      '.address',
+      '.name',
+      '.holder',
+      '.ant-typography',
+      'a[href*="etherscan"], a[href*="basescan"], a[href*="solscan"], a[href*="arbiscan"], a[href*="bscscan"], a[href*="snowtrace"]',
+      'a[href*="/address/"]',
+      'span',
+      'div'
+    ];
+
+    function looksLikeAddress(text) {
+      if (!text) return false;
+      const t = text.trim();
+      // hex evm
+      if (/^0x[0-9a-fA-F]{4,}$/.test(t)) return true;
+      // short labeled addrs or ENS-like
+      if (t.endsWith('.eth') || t.includes(':') || t.includes('...')) return true;
+      // base/sol generic: contains dots or is long
+      if (t.length >= 35) return true;
+      return false;
+    }
+
+    function likelyNameNode(node) {
+      const txt = (node.textContent || '').trim();
+      if (!txt) return false;
+      // exclude cells that are clearly numeric (balances, percent)
+      if (/^[\d,.%\s]+$/.test(txt)) return false;
+      if (looksLikeAddress(txt)) return true;
+      // include generic label-like texts
+      if (/holder|wallet|address|ens/i.test(txt)) return true;
+      // avoid buttons/controls
+      if (node.closest('button, [role="button"], input, select, textarea')) return false;
+      return true;
+    }
+
+    for (const root of candidateRoots) {
+      for (const rowSel of holderRowSelectors) {
+        const rows = root.querySelectorAll(rowSel);
+        rows.forEach((row) => {
+          for (const cellSel of nameCellSelectors) {
+            const cells = row.querySelectorAll(cellSel);
+            cells.forEach((cell) => {
+              if (likelyNameNode(cell)) nameNodes.add(cell);
+            });
+          }
+        });
+      }
+    }
+
+    // De-duplicate by element
+    return Array.from(nameNodes);
+  }
+
+  function loadOriginals() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      return raw ? JSON.parse(raw) : {};
+    } catch { return {}; }
+  }
+
+  function saveOriginals(map) {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+  }
+
+  function labelNode(node, label) {
+    if (!node) return;
+    if (!node.hasAttribute(TAG_ATTR)) {
+      node.setAttribute(TAG_ATTR, '1');
+      node.dataset.originalText = node.textContent || '';
+    }
+    node.textContent = label;
+  }
+
+  function restoreNode(node) {
+    if (!node) return;
+    if (node.hasAttribute(TAG_ATTR)) {
+      const original = node.dataset.originalText || '';
+      node.textContent = original;
+      node.removeAttribute(TAG_ATTR);
+      delete node.dataset.originalText;
+    }
+  }
+
+  function trackTopHolders(count) {
+    const nodes = getTopHolderNameNodes();
+    if (!nodes.length) return { ok: false, message: 'No holder names found on this page.' };
+
+    // stable order by DOM position
+    const ordered = nodes.sort((a,b) => a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1);
+
+    const originals = loadOriginals();
+    let applied = 0;
+
+    for (let i = 0; i < ordered.length && applied < count; i++) {
+      const node = ordered[i];
+      const key = node.dataset.gmgnKey || node.outerHTML.slice(0, 100);
+      if (!originals[key]) {
+        originals[key] = node.textContent || '';
+      }
+      labelNode(node, `Top Holder ${applied + 1}`);
+      applied++;
+    }
+
+    saveOriginals(originals);
+    return { ok: true, message: `Tracking ${applied} holder(s).` };
+  }
+
+  function untrackAll() {
+    const nodes = getTopHolderNameNodes();
+    const originals = loadOriginals();
+
+    let reverted = 0;
+    nodes.forEach((node) => {
+      if (node.hasAttribute(TAG_ATTR)) {
+        restoreNode(node);
+        reverted++;
+      } else {
+        // try map by key
+        const key = node.dataset.gmgnKey || node.outerHTML.slice(0, 100);
+        if (originals[key]) {
+          node.textContent = originals[key];
+          reverted++;
+        }
+      }
+    });
+
+    // Clear tag attributes as well
+    Object.keys(originals).forEach((k) => delete originals[k]);
+    saveOriginals(originals);
+
+    return { ok: true, message: `Untracked ${reverted} holder(s).` };
+  }
+
+  chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+    try {
+      if (msg && msg.type === 'GMGN_TRACK') {
+        const n = Math.max(1, Math.min(100, Number(msg.count) || 1));
+        const res = trackTopHolders(n);
+        sendResponse(res);
+        return true;
+      }
+      if (msg && msg.type === 'GMGN_UNTRACK') {
+        const res = untrackAll();
+        sendResponse(res);
+        return true;
+      }
+    } catch (e) {
+      sendResponse({ ok: false, message: String(e?.message || e) });
+      return true;
+    }
+  });
+})();

--- a/gmgn-tracker/manifest.json
+++ b/gmgn-tracker/manifest.json
@@ -1,0 +1,35 @@
+{
+  "manifest_version": 3,
+  "name": "GMGN Top Holder Tracker",
+  "version": "0.1.0",
+  "description": "Rename and track GMGN.ai top holder wallets (Track/Untrack first N).",
+  "permissions": [
+    "storage",
+    "scripting",
+    "activeTab"
+  ],
+  "host_permissions": [
+    "https://gmgn.ai/*",
+    "https://www.gmgn.ai/*"
+  ],
+  "action": {
+    "default_title": "GMGN Tracker",
+    "default_popup": "popup.html"
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "https://gmgn.ai/*",
+        "https://www.gmgn.ai/*"
+      ],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ],
+  "icons": {
+    "16": "icons/icon16.png",
+    "32": "icons/icon32.png",
+    "48": "icons/icon48.png",
+    "128": "icons/icon128.png"
+  }
+}

--- a/gmgn-tracker/popup.css
+++ b/gmgn-tracker/popup.css
@@ -1,0 +1,10 @@
+body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Arial, sans-serif; margin: 0; padding: 0; }
+.container { padding: 12px; width: 280px; }
+h1 { font-size: 16px; margin: 0 0 10px; }
+label { display: block; margin-bottom: 6px; font-size: 12px; color: #444; }
+#count { width: 100%; padding: 6px; box-sizing: border-box; margin-bottom: 10px; }
+.buttons { display: flex; gap: 8px; }
+button { flex: 1; padding: 8px 12px; border-radius: 6px; border: 1px solid #0a84ff; background: #0a84ff; color: #fff; cursor: pointer; }
+button.secondary { background: #fff; color: #0a84ff; }
+button:disabled { opacity: 0.6; cursor: default; }
+.status { font-size: 12px; color: #333; min-height: 18px; margin-top: 8px; }

--- a/gmgn-tracker/popup.html
+++ b/gmgn-tracker/popup.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>GMGN Tracker</title>
+    <link rel="stylesheet" href="popup.css" />
+  </head>
+  <body>
+    <div class="container">
+      <h1>GMGN Top Holders</h1>
+      <label for="count">How many to track:</label>
+      <input id="count" type="number" min="1" max="100" value="5" />
+      <div class="buttons">
+        <button id="track">Track</button>
+        <button id="untrack" class="secondary">Untrack</button>
+      </div>
+      <p id="status" class="status"></p>
+    </div>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/gmgn-tracker/popup.js
+++ b/gmgn-tracker/popup.js
@@ -1,0 +1,50 @@
+const statusEl = document.getElementById('status');
+const countEl = document.getElementById('count');
+const trackBtn = document.getElementById('track');
+const untrackBtn = document.getElementById('untrack');
+
+function setStatus(text) {
+  statusEl.textContent = text || '';
+}
+
+function sendToActiveTab(message) {
+  return new Promise((resolve, reject) => {
+    try {
+      chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+        const tab = tabs && tabs[0];
+        if (!tab || !tab.id) {
+          reject(new Error('No active tab'));
+          return;
+        }
+        chrome.tabs.sendMessage(tab.id, message, resolve);
+      });
+    } catch (e) {
+      reject(e);
+    }
+  });
+}
+
+trackBtn.addEventListener('click', async () => {
+  const n = Math.max(1, Math.min(100, Number(countEl.value) || 1));
+  trackBtn.disabled = true; untrackBtn.disabled = true; setStatus('Tracking...');
+  try {
+    const res = await sendToActiveTab({ type: 'GMGN_TRACK', count: n });
+    setStatus(res && res.message ? res.message : 'Done');
+  } catch (e) {
+    setStatus('Failed: ' + (e.message || e));
+  } finally {
+    trackBtn.disabled = false; untrackBtn.disabled = false;
+  }
+});
+
+untrackBtn.addEventListener('click', async () => {
+  trackBtn.disabled = true; untrackBtn.disabled = true; setStatus('Untracking...');
+  try {
+    const res = await sendToActiveTab({ type: 'GMGN_UNTRACK' });
+    setStatus(res && res.message ? res.message : 'Reverted');
+  } catch (e) {
+    setStatus('Failed: ' + (e.message || e));
+  } finally {
+    trackBtn.disabled = false; untrackBtn.disabled = false;
+  }
+});


### PR DESCRIPTION
Implement a Chrome extension to rename GMGN.ai top holder wallets for tracking and provide options to track a specified number of holders or untrack all.

---
<a href="https://cursor.com/background-agent?bcId=bc-fbf4dedb-c238-4acd-b6d5-9754556fe144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fbf4dedb-c238-4acd-b6d5-9754556fe144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

